### PR TITLE
Disable zstd and add CI image workflow

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:20.04 as builder
+
+LABEL org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="CI container for Hyperledger Solang github actions"
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y
+RUN apt-get upgrade -y
+RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3
+
+RUN git clone --single-branch --branch solana-rustc/15.0-2022-08-09 \
+    https://github.com/solana-labs/llvm-project.git
+
+WORKDIR /llvm-project
+
+RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off \
+    -DLLVM_ENABLE_PROJECTS=clang\;lld \
+    -DLLVM_TARGETS_TO_BUILD=WebAssembly\;BPF \
+    -DLLVM_ENABLE_ZSTD=Off \
+    -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/llvm15.0 llvm
+
+RUN cmake --build . --target install
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y zlib1g-dev pkg-config libssl-dev git libffi-dev curl gcc g++ make python3
+RUN apt-get clean
+RUN apt-get autoclean
+
+# Get Rust
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.64.0
+
+COPY --from=builder /llvm15.0 /llvm15.0/
+
+ENV PATH="/llvm15.0/bin:/root/.cargo/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
+
+# Install Solana (x86-64 only, does not work on arm)
+RUN if test `arch` = x86_64; then sh -c "$(curl -sSfL https://release.solana.com/v1.11.10/install)"; fi
+
+# Install Anchor tools
+RUN cargo install --git https://github.com/coral-xyz/anchor --tag v0.25.0 anchor-cli

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
@@ -48,6 +49,7 @@ jobs:
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
@@ -81,7 +83,8 @@ jobs:
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
-        '-DLLVM_ENABLE_PROJECTS=clang;lld'
+        -DLLVM_ENABLE_PROJECTS='clang;lld'
+        -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm15.0 llvm
       working-directory: C:\llvm-project
     - run: cmake --build . --target install
@@ -112,6 +115,7 @@ jobs:
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
@@ -144,6 +148,7 @@ jobs:
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,11 @@
+name: Build and push ci image
+on: [workflow_dispatch]
+jobs:
+  build-push-ci-image:
+    runs-on: linux-arm64
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v1
+    - run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/solang:ci --push .github


### PR DESCRIPTION
This PR disable ZSTD from the LLVM builds.

The test builds are running [here](https://github.com/hyperledger/solang-llvm/actions/runs/4164876550/jobs/7207108271).