### PR TITLE
Fix CI image workflow

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -8,4 +8,4 @@ jobs:
       uses: actions/checkout@v1
     - run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/solang:ci --push .github
+          docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/${GITHUB_REPOSITORY}:ci --push .github


### PR DESCRIPTION
The CI container image is now uploaded to the current repository.