### PR TITLE
Update workflow name

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -3,7 +3,7 @@ on:
     tags:
     - 'llvm*'
 
-name: Build Release Binaries
+name: Build LLVM Binaries
 
 jobs:
   linux-x86-64:


### PR DESCRIPTION
The workflow to build LLVM binaries must not be called `Build Release Binaries`, because we are not doing so.