### PR TITLE
Use newer SBF target rather than BPF

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -20,7 +20,7 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_TARGETS_TO_BUILD='WebAssembly;SBF'
         -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
@@ -48,7 +48,7 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_TARGETS_TO_BUILD='WebAssembly;SBF'
         -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
@@ -114,7 +114,7 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_TARGETS_TO_BUILD='WebAssembly;SBF'
         -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/
@@ -147,7 +147,7 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
-        -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
+        -DLLVM_TARGETS_TO_BUILD='WebAssembly;SBF'
         -DLLVM_ENABLE_ZSTD=Off
         -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm15.0 llvm
       working-directory: ./llvm-project/


### PR DESCRIPTION
Solana's LLVM fork has a new target SBF which should be used rather BPF.