### PR TITLE
Use Ubuntu 20.04 rather than 22.04

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:20.04 as builder
 
 LABEL org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.description="CI container for Hyperledger Solang github actions"
@@ -22,7 +22,7 @@ RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off \
 RUN cmake --build . --target install && \
 	find /llvm15.0/ -type f -executable -exec sh -c "file '{}' | grep -q 'not stripped' " \; -print | xargs strip
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \

--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -8,7 +8,7 @@ name: Build LLVM Binaries
 jobs:
   linux-x86-64:
     name: Linux x86-64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.1.0

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -8,4 +8,4 @@ jobs:
         uses: actions/checkout@v3.1.0
       - run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker buildx build --provenance=false --platform linux/amd64,linux/arm64 -t ghcr.io/${GITHUB_REPOSITORY}:ci-4 --push .github
+          docker buildx build --provenance=false --platform linux/amd64,linux/arm64 -t ghcr.io/${GITHUB_REPOSITORY}:ci-5 --push .github


### PR DESCRIPTION
We've had a few users reporting that solang does not work in their environment; usually this is ubuntu 20.04 WSL.