### PR TITLE
Add `libudev-dev` Installation to Dockerfile

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0" \
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && \
 	apt-get upgrade -y && \
-	apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3 file
+	apt-get install -y libz-dev libudev-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3 file
 
 RUN git clone --single-branch --branch solana-rustc/15.0-2022-08-09 \
     https://github.com/solana-labs/llvm-project.git


### PR DESCRIPTION
Include the installation of the `libudev-dev` package in the `Dockerfile`

This is needed for [this PR](https://github.com/hyperledger/solang/pull/1542)